### PR TITLE
Lower priority to slate_post_state

### DIFF
--- a/slate-admin-theme.php
+++ b/slate-admin-theme.php
@@ -43,7 +43,7 @@ function slate_get_user_admin_color(){
 }
 
 // Remove the hyphen before the post state
-add_filter( 'display_post_states', 'slate_post_state' );
+add_filter( 'display_post_states', 'slate_post_state', 90 );
 function slate_post_state( $post_states ) {
 	if ( !empty($post_states) ) {
 		$state_count = count($post_states);


### PR DESCRIPTION
I assigned a lower priority to 'slate_post_state' function because 'display_post_states' filter can be used to append custom post status to custom post types so hyphen would be still visible if filter is applied before
